### PR TITLE
Выжигание стамины

### DIFF
--- a/code/modules/marines/Marine_Weapons_V2.dm
+++ b/code/modules/marines/Marine_Weapons_V2.dm
@@ -1,22 +1,26 @@
 ///***Bullets***///
 /obj/item/projectile/bullet/m4a3 //Colt 45 Pistol
 	damage = 25
+	stamina = 15
 	sound_fx = 1
 	dispersion = 0.5
 	penetration = -20
 
 /obj/item/projectile/bullet/vp78
 	damage = 40
+	stamina = 20
 	sound_fx = 1
 	dispersion = 0.6
 
 /obj/item/projectile/bullet/m44m //44 Magnum Peacemaker
 	damage = 45
+	stamina = 20
 	sound_fx = 1
 	dispersion = 0.6
 
 /obj/item/projectile/bullet/m39 // M39 SMG
 	damage = 15
+	stamina = 15
 	sound_fx = 1
 	dispersion = 1
 	penetration = -40
@@ -33,6 +37,7 @@
 
 /obj/item/projectile/bullet/m41 //M41 Assault Rifle
 	damage = 20
+	stamina = 10
 	sound_fx = 1
 	dispersion = 0.5
 	penetration = 30
@@ -43,15 +48,18 @@
 
 /obj/item/projectile/bullet/m37/buckshot
 	damage = 13
+	stamina = 10
 	dispersion = 1.5
 
 /obj/item/projectile/bullet/m37/flechette
 	damage = 30
+	stamina = 20
 	dispersion = 1
 	penetration = -60
 
 /obj/item/projectile/bullet/m37/slug
 	damage = 150
+	stamina = 90
 	dispersion = 0.5
 	penetration = 60
 
@@ -68,6 +76,7 @@
 
 /obj/item/projectile/bullet/a10x28 //M59B Smartgun
 	damage = 30
+	stamina = 10
 	sound_fx = 1
 	dispersion = 0.5
 
@@ -75,6 +84,7 @@
 	icon_state = "tracer"
 	layer = 16
 	damage = 120
+	stamina = 50
 	sound_fx = 1
 	dispersion = 0.2
 	penetration = 80
@@ -108,12 +118,14 @@
 
 /obj/item/projectile/bullet/machinegun
 	damage = 60
+	stamina = 20
 	sound_fx = 1
 	dispersion = 0.5
 	penetration = 50
 
 /obj/item/projectile/bullet/turret
 	damage = 25
+	stamina = 20
 	sound_fx = 1
 	dispersion = 0.5
 	penetration = -30

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_speed.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_speed.dm
@@ -4,6 +4,13 @@
 		. +=  move_delay_add + 3
 	else
 		. += move_delay_add + config.alien_delay	//move_delay_add is used to slow aliens with stuns
+	var/slow = (staminaloss/(maxHealth*2))*100
+	if(slow > 80)
+		. += 3	 
+	if((slow<=80)&&(slow > 60))
+		. += 2
+	if((slow<=60)&&(slow > 40))
+		. += 1	
 
 /mob/living/carbon/alien/humanoid/drone/movement_delay()
 	. = ..()


### PR DESCRIPTION
При попадании в алиумов (и маринов) пули выжигают стамину. А так же теперь замедляют алиумов. По  идее это должно передвинуть баланс в сторону маринов. Но, пули выжигают стамину не только у алиумов, так что морпехом придётся стрелять точнее. Возможно стоит повысить реген стамины алиумам или добавить соответствующее умение к ним в ветку. 
