### PR TITLE
Убрал обработку реагентов у взрослых особей, а точнее вместо метаболи…

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -16,3 +16,9 @@
 		temperature = max(loc_temp, temperature-change)
 	temp_change = (temperature - current)
 	return temp_change
+
+/mob/living/carbon/alien/humanoid/handle_chemicals_in_body()
+	if(reagents && reagents.reagent_list.len)
+		var/datum/reagents/D = reagents
+		for(var/datum/reagent/R in D.reagent_list)
+			D.del_reagent(R.id)


### PR DESCRIPTION
…зма мы их просто удаляем из организма.

А можно былоб проще сделать, но блокировка создания холдера для регов начнет рантаймить лайф и мало ли что там еще могло произойти в этом случае.